### PR TITLE
Quote check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_package_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_package_template.md
@@ -23,7 +23,7 @@
 - [ ] The `Publication` column in the `.janno` file is filled and the respective `.bib` file has complete entries for the listed mentioned keys.
 - [ ] The `.janno` file does not include any empty columns or columns only filled with `n/a`.
 - [ ] The order of columns in the `.janno` file adheres to the standard order as defined in the Poseidon schema [here](https://github.com/poseidon-framework/poseidon-schema/blob/master/janno_columns.tsv).
-- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use double quotes (`"..."`) to enclose text fields where it is strictly necessary.
+- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use single- or double quotes (`"..."`, `'...'`) to enclose text fields where it is strictly necessary (i.e. their entry includes a TAB).
 
 ***
 

--- a/.github/PULL_REQUEST_TEMPLATE/add_package_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_package_template.md
@@ -23,6 +23,7 @@
 - [ ] The `Publication` column in the `.janno` file is filled and the respective `.bib` file has complete entries for the listed mentioned keys.
 - [ ] The `.janno` file does not include any empty columns or columns only filled with `n/a`.
 - [ ] The order of columns in the `.janno` file adheres to the standard order as defined in the Poseidon schema [here](https://github.com/poseidon-framework/poseidon-schema/blob/master/janno_columns.tsv).
+- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use double quotes (`"..."`) to enclose text fields where it is strictly necessary.
 
 ***
 

--- a/.github/PULL_REQUEST_TEMPLATE/modify_package_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/modify_package_template.md
@@ -11,6 +11,7 @@
 - [ ] The changes were documented in the respective `CHANGELOG` files. If no `CHANGELOG` files existed previously it was added here.
 - [ ] The `lastModified` fields of the affected `POSEIDON.yml` files were updated.
 - [ ] The `contributor` fields were updated with `name`, `email` and `orcid` of the relevant, new contributors.
+- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use double quotes (`"..."`) to enclose text fields where it is strictly necessary.
 
 ***
 

--- a/.github/PULL_REQUEST_TEMPLATE/modify_package_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/modify_package_template.md
@@ -11,7 +11,7 @@
 - [ ] The changes were documented in the respective `CHANGELOG` files. If no `CHANGELOG` files existed previously it was added here.
 - [ ] The `lastModified` fields of the affected `POSEIDON.yml` files were updated.
 - [ ] The `contributor` fields were updated with `name`, `email` and `orcid` of the relevant, new contributors.
-- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use double quotes (`"..."`) to enclose text fields where it is strictly necessary.
+- [ ] The `.janno` and the `.ssf` files are not fully quoted, so they only use single- or double quotes (`"..."`, `'...'`) to enclose text fields where it is strictly necessary (i.e. their entry includes a TAB).
 
 ***
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -36,3 +36,7 @@ jobs:
     - name: Check if all files have UTF-8 encoding and Unix line endings
       run: ./checkFileEncoding.sh
       working-directory: ./data
+
+    - name: Check if any .janno and .ssf files start with a double-quote character
+      run: ./checkDoubleQuote.sh
+      working-directory: ./data

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,6 +37,6 @@ jobs:
       run: ./checkFileEncoding.sh
       working-directory: ./data
 
-    - name: Check if any .janno and .ssf files start with a double-quote character
-      run: ./checkDoubleQuote.sh
+    - name: Check if any .janno and .ssf files start with a single or double-quote character
+      run: ./checkQuotes.sh
       working-directory: ./data

--- a/checkDoubleQuote.sh
+++ b/checkDoubleQuote.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# function to check if a file starts with a double-quote
+starts_with_quote() {
+  if grep -q '^"' "$1"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# file extensions to search for
+extensions=("janno" "ssf")
+
+# initialize exit code
+exit_code=0
+
+# recursive search for files and check them
+for ext in "${extensions[@]}"; do
+  while IFS= read -r -d '' file; do
+    if starts_with_quote "$file"; then
+      echo "FAIL: $file"
+      exit_code=1
+    fi
+  done < <(find . -type f -name "*.$ext" -not -path "./.git*" -print0)
+done
+
+exit $exit_code

--- a/checkDoubleQuote.sh
+++ b/checkDoubleQuote.sh
@@ -2,7 +2,7 @@
 
 # function to check if a file starts with a double-quote
 starts_with_quote() {
-  if grep -q '^"' "$1"; then
+  if grep -q '^"' "${1}"; then
     return 0
   else
     return 1
@@ -18,11 +18,11 @@ exit_code=0
 # recursive search for files and check them
 for ext in "${extensions[@]}"; do
   while IFS= read -r -d '' file; do
-    if starts_with_quote "$file"; then
-      echo "FAIL: $file"
+    if starts_with_quote "${file}"; then
+      echo "FAIL: ${file}"
       exit_code=1
     fi
-  done < <(find . -type f -name "*.$ext" -not -path "./.git*" -print0)
+  done < <(find . -type f -name "*.${ext}" -not -path "./.git*" -print0)
 done
 
-exit $exit_code
+exit ${exit_code}

--- a/checkQuotes.sh
+++ b/checkQuotes.sh
@@ -2,7 +2,7 @@
 
 # function to check if a file starts with a double-quote
 starts_with_quote() {
-  if grep -q '^"' "${1}"; then
+  if grep -q ^[\"\'] "${1}"; then
     return 0
   else
     return 1


### PR DESCRIPTION
In an effort to further reduce the review burden through automation I added another check to the validation pipeline.

This one checks any incoming `.ssf` and `.janno` files for a double quote (`"`) character at the beginning of the first line, which is a strong indicator for a "quoted" .tsv file. We decided to not allow these in the public archives to get better `git` diffs. But as they are still allowed in Poseidon packages in general (`trident` doesn't care if the .tsv files are quoted or not) and as popular software tools add quotes by default (e.g. Libre Office), they sometimes appear in submissions.

I also spelled this so far hidden requirement out in the submission checklists. Note that these checklists are mirrored (through an `include` statement) on the website [here](https://www.poseidon-adna.org/#/archive_submission_guide).