### PR TITLE
updated .bib file after publication

### DIFF
--- a/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees.bib
+++ b/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees.bib
@@ -3,10 +3,11 @@
   author = {Guido Alberto Gnecchi-Ruscone and Zsófia Rácz and Levente Samu and Tamás Szeniczey and Norbert Faragó and Corina Knipper and Ronny Friedrich and Denisa Zlámalová and Luca Traverso and Salvatore Liccardo and Sandra Wabnitz and Divyaratan Popli and Ke Wang and Rita Radzeviciute and Bence Gulyás and István Koncz and Csilla Balogh and Gabriella M. Lezsák and Viktor Mácsai and Magdalena M. E. Bunbury and Olga Spekker and Petrus le Roux and Anna Szécsényi-Nagy and Balázs Gusztáv Mende and Heidi Colleran and Tamás Hajdu and Patrick Geary and Walter Pohl and Tivadar Vida and Johannes Krause and Zuzana Hofmanová},
   year = {2024},
   journal = {Nature},
-  volume = {n/a},
-  issue = {n/a},
+  volume = {629},
+  pages = {376--383},
+  issue = {8011},
   publisher = {Springer Science and Business Media {LLC}},
-  doi = {n/a},
-  url = {n/a},
+  doi = {https://doi.org/10.1038/s41586-024-07312-4},
+  url = {https://www.nature.com/articles/s41586-024-07312-4},
 }
 

--- a/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/CHANGELOG.md
+++ b/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/CHANGELOG.md
@@ -1,1 +1,2 @@
+- V 1.0.2: Added missing information to the .bib file
 - V 1.0.1: added info to .janno file after publication

--- a/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/POSEIDON.yml
+++ b/2024_GnecchiRuscone_CarpathianBasinAvarPedigrees/POSEIDON.yml
@@ -6,8 +6,8 @@ contributor:
 - name: Luca Traverso
   email: luca_traverso@eva.mpg.de
   orcid: 0000-0001-5749-5751
-packageVersion: 1.0.1
-lastModified: 2024-05-02
+packageVersion: 1.0.2
+lastModified: 2024-12-03
 genotypeData:
   format: PLINK
   genoFile: 2024_GnecchiRuscone_CarpathianBasinAvarPedigrees.bed
@@ -20,5 +20,5 @@ genotypeData:
 jannoFile: 2024_GnecchiRuscone_CarpathianBasinAvarPedigrees.janno
 jannoFileChkSum: a11658e8d1dd123bc7deee4ed4f26540
 bibFile: 2024_GnecchiRuscone_CarpathianBasinAvarPedigrees.bib
-bibFileChkSum: 58a9ded25141e6f88f747a77db0970f3
+bibFileChkSum: ce19b7e726bf75ede8ab85d6b4945e7d
 changelogFile: CHANGELOG.md


### PR DESCRIPTION
### PR Checklist for modifying one or multiple existing packages

- [x] The changes maintain the structural integrity of the affected packages.
- [x] The checksums of the modified files in the respective `POSEIDON.yml` files were adjusted properly.
- [x] Every file in the submission is correctly referenced in the relevant `POSEIDON.yml` files and there are no additional, supplementary files in the submission that are not documented there.

***

- [x] The `packageVersion` numbers of the affected packages were increased in their `POSEIDON.yml` files.
- [x] The changes in the `packageVersion` followed the Poseidon [Package versioning policy](https://github.com/poseidon-framework/poseidon-schema?tab=readme-ov-file#package-versioning).
- [x] The changes were documented in the respective `CHANGELOG` files. If no `CHANGELOG` files existed previously it was added here.
- [x] The `lastModified` fields of the affected `POSEIDON.yml` files were updated.
- [x] The `contributor` fields were updated with `name`, `email` and `orcid` of the relevant, new contributors.
- [x] The `.janno` and the `.ssf` files are not fully quoted, so they only use single- or double quotes (`"..."`, `'...'`) to enclose text fields where it is strictly necessary (i.e. their entry includes a TAB).

***

- [x] All affected packages pass a validation with `trident validate --fullGeno`.

***

- [x] Large genotype data files are properly tracked with Git LFS and not directly pushed to the repository. For an instruction on how to set up Git LFS please look [here](https://www.poseidon-adna.org/#/archive_submission_guide?id=submitting-the-package). If you accidentally pushed the files the wrong way you can fix it with `git lfs migrate import --no-rewrite path/to/file.bed` (see [here](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.adoc#import-without-rewriting-history)).
