### PR TITLE
Fixed source_tissue in 2020_Bongers

### DIFF
--- a/2020_Bongers_SouthPeru/Bongers_SouthPeru.janno
+++ b/2020_Bongers_SouthPeru/Bongers_SouthPeru.janno
@@ -1,7 +1,7 @@
 Poseidon_ID	Genetic_Sex	Group_Name	Collection_ID	Country	Location	Date_Type	Date_BC_AD_Start	Date_BC_AD_Median	Date_BC_AD_Stop	Source_Tissue	Capture_Type	Library_Built	Genotype_Ploidy	Nr_SNPs	Primary_Contact	Publication	Note	Genetic_Source_Accession_IDs
-UC8-8168	U	Peru_Chincha_LH	UC8-8168	Peru	SouthCoast	contextual	1400	1450	1500	uc8-8168	OtherCapture	ds	haploid	676429	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
-UC8-8173	U	Peru_Chincha_LH	UC8-8173	Peru	SouthCoast	contextual	1400	1450	1500	uc8-8173	OtherCapture	ds	haploid	1000073	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
-UC12-12	U	Peru_Chincha_LH	UC12-12	Peru	SouthCoast	contextual	1400	1450	1500	uc12-12	OtherCapture	ds	haploid	841374	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
-UC12-20	U	Peru_Chincha_LH	UC12-20	Peru	SouthCoast	contextual	1400	1450	1500	uc12-20	OtherCapture	ds	haploid	1005991	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
-UC12-24	U	Peru_Chincha_LH	UC12-24	Peru	SouthCoast	contextual	1400	1450	1500	uc12-24	OtherCapture	ds	haploid	857158	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
-UC12-25	U	Peru_Chincha_LH	UC12-25	Peru	SouthCoast	contextual	1400	1450	1500	uc12-25	OtherCapture	ds	haploid	995652	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC8-8168	U	Peru_Chincha_LH	UC8-8168	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	676429	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC8-8173	U	Peru_Chincha_LH	UC8-8173	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	1000073	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC12-12	U	Peru_Chincha_LH	UC12-12	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	841374	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC12-20	U	Peru_Chincha_LH	UC12-20	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	1005991	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC12-24	U	Peru_Chincha_LH	UC12-24	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	857158	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726
+UC12-25	U	Peru_Chincha_LH	UC12-25	Peru	SouthCoast	contextual	1400	1450	1500	tooth_molar	OtherCapture	ds	haploid	995652	Fehren-Schmitz, Lars	BongersPNAS2020;AADR;AADRv443	PASS	PRJEB37726

--- a/2020_Bongers_SouthPeru/CHANGELOG.md
+++ b/2020_Bongers_SouthPeru/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 2.2.1: fixed Source Tissue in 2020_Bongers
 - V 2.2.0: Update of references in the .bib file
 - V 2.1.0: added a .ssf file
 - V 2.0.1: Genetic_Source_Accession_IDs added

--- a/2020_Bongers_SouthPeru/POSEIDON.yml
+++ b/2020_Bongers_SouthPeru/POSEIDON.yml
@@ -5,8 +5,8 @@ description: Six Late Horizon individuals from two cemeteries in the Chincha Val
 contributor:
 - name: Clemens Schmid
   email: schmid@shh.mpg.de
-packageVersion: 2.2.0
-lastModified: 2023-07-04
+packageVersion: 2.2.1
+lastModified: 2024-12-12
 genotypeData:
   format: PLINK
   genoFile: Bongers_SouthPeru.bed
@@ -17,7 +17,7 @@ genotypeData:
   indFileChkSum: b2dd0a3251ecf17679ec7a743e4748df
   snpSet: 1240K
 jannoFile: Bongers_SouthPeru.janno
-jannoFileChkSum: e0b4d750e749e51804c8193c51d65c16
+jannoFileChkSum: 00cb8f9df4df445e44e0b6bed44501df
 sequencingSourceFile: ENAtable.ssf
 sequencingSourceFileChkSum: 1874eafc95e683aa270818578ee216b8
 bibFile: Bongers_SouthPeru.bib


### PR DESCRIPTION
### PR Checklist for modifying one or multiple existing packages

- [x] The changes maintain the structural integrity of the affected packages.
- [x] The checksums of the modified files in the respective `POSEIDON.yml` files were adjusted properly.
- [x] Every file in the submission is correctly referenced in the relevant `POSEIDON.yml` files and there are no additional, supplementary files in the submission that are not documented there.

***

- [x] The `packageVersion` numbers of the affected packages were increased in their `POSEIDON.yml` files.
- [x] The changes in the `packageVersion` followed the Poseidon [Package versioning policy](https://github.com/poseidon-framework/poseidon-schema?tab=readme-ov-file#package-versioning).
- [x] The changes were documented in the respective `CHANGELOG` files. If no `CHANGELOG` files existed previously it was added here.
- [x] The `lastModified` fields of the affected `POSEIDON.yml` files were updated.
- [x] The `contributor` fields were updated with `name`, `email` and `orcid` of the relevant, new contributors.
- [x] The `.janno` and the `.ssf` files are not fully quoted, so they only use single- or double quotes (`"..."`, `'...'`) to enclose text fields where it is strictly necessary (i.e. their entry includes a TAB).

***

- [x] All affected packages pass a validation with `trident validate --fullGeno`.

***

- [x] Large genotype data files are properly tracked with Git LFS and not directly pushed to the repository. For an instruction on how to set up Git LFS please look [here](https://www.poseidon-adna.org/#/archive_submission_guide?id=submitting-the-package). If you accidentally pushed the files the wrong way you can fix it with `git lfs migrate import --no-rewrite path/to/file.bed` (see [here](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.adoc#import-without-rewriting-history)).
