### PR TITLE
Changed the way linux file endings are enforced

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-# all line endings should be linux file endings
-* text eol=lf
 # the big genotype data files should be handled with the lfs system
 *.bed filter=lfs diff=lfs merge=lfs -text
 *.bed.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Clone data repo
+      uses: actions/checkout@v3
+      with:
+        path: data
+
     - name: Check if all files have UTF-8 encoding and Unix line endings
       run: ./checkFileEncoding.sh
       working-directory: ./data
@@ -20,11 +25,6 @@ jobs:
       run: |
         wget https://github.com/poseidon-framework/poseidon-hs/releases/latest/download/trident-Linux
         chmod +x trident-Linux
-
-    - name: Clone data repo
-      uses: actions/checkout@v3
-      with:
-        path: data
 
     - name: Validation
       run: ./trident-Linux validate -d data --ignoreGeno --logMode VerboseLog

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,12 +11,16 @@ jobs:
     name: validate packages
     runs-on: ubuntu-latest
     steps:
-        
+
+    - name: Check if all files have UTF-8 encoding and Unix line endings
+      run: ./checkFileEncoding.sh
+      working-directory: ./data
+
     - name: Install trident
       run: |
         wget https://github.com/poseidon-framework/poseidon-hs/releases/latest/download/trident-Linux
         chmod +x trident-Linux
-        
+
     - name: Clone data repo
       uses: actions/checkout@v3
       with:
@@ -31,10 +35,6 @@ jobs:
 
     - name: Check if all registered files are actually LFS pointers
       run: git lfs fsck --pointers
-      working-directory: ./data
-
-    - name: Check if all files have UTF-8 encoding and Unix line endings
-      run: ./checkFileEncoding.sh
       working-directory: ./data
 
     - name: Check if any .janno and .ssf files start with a single or double-quote character


### PR DESCRIPTION
I had an idea how to solve #215 and to some part https://github.com/poseidon-framework/poseidon-hs/issues/311.

We don't let Git do its thing with `* text eol=lf` any more, but instead rely entirely on the validation with the `checkFileEncoding.sh` script. And to prevent trident reporting checksum issues before this script ran, we move it up in the validation GitHub Action.

A line ending warning in trident (as suggested in https://github.com/poseidon-framework/poseidon-hs/issues/311) could still be implemented for convenience. But this way we can be sure that a wrong checksum reported by the GitHub Action is not caused by line ending mixups.